### PR TITLE
docker: initial configuration and demo app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 dist/
 build/
 docs/_build/
+.eggs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Flask-Menu
+# Copyright (C) 2015 CERN.
+#
+# Flask-Menu is free software; you can redistribute it and/or modify
+# it under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+FROM python:2.7
+ADD . /code
+WORKDIR /code
+RUN pip install pep257
+RUN pip install sphinx
+RUN python setup.py develop

--- a/examples/simple/app.py
+++ b/examples/simple/app.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Flask-Menu
+# Copyright (C) 2015 CERN.
+#
+# Flask-Menu is free software; you can redistribute it and/or modify
+# it under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+"""A simple demo application showing Flask-Menu in action.
+
+Usage:
+  $ fig up
+  $ firefox http://0.0.0.0:5000/
+  $ firefox http://0.0.0.0:5000/first
+  $ firefox http://0.0.0.0:5000/second
+"""
+
+from flask import Flask
+from flask import render_template_string
+from flask.ext import menu
+
+app = Flask(__name__)
+menu.Menu(app=app)
+
+
+def tmpl_show_menu():
+    """Show menu with current page decorated by asterisk."""
+    return render_template_string(
+        """
+        {%- for item in current_menu.children %}
+            {% if item.active %}*{% endif %}{{ item.text }}
+        {% endfor -%}
+        """)
+
+
+@app.route('/')
+@menu.register_menu(app, '.', 'Home')
+def index():
+    """Home page."""
+    return tmpl_show_menu()
+
+
+@app.route('/first')
+@menu.register_menu(app, '.first', 'First', order=0)
+def first():
+    """First page."""
+    return tmpl_show_menu()
+
+
+@app.route('/second')
+@menu.register_menu(app, '.second', 'Second', order=1)
+def second():
+    """Second page."""
+    return tmpl_show_menu()
+
+
+if __name__ == '__main__':
+    app.run(host="0.0.0.0", debug=True)

--- a/fig.yml
+++ b/fig.yml
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Flask-Menu
+# Copyright (C) 2015 CERN.
+#
+# Flask-Menu is free software; you can redistribute it and/or modify
+# it under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+web:
+  build: .
+  command: python examples/simple/app.py
+  ports:
+   - "5000:5000"
+  volumes:
+   - .:/code

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-Menu
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Flask-Menu is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -52,7 +52,7 @@ tests_require = [
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
     'pytest>=2.6.1',
-    'coverage'
+    'coverage<4.0a1'
 ]
 
 setup(


### PR DESCRIPTION
* Initial release of docker/fig configuration.  E.g. how to run tests
  while developing: `fig build && fig run web python setup.py test`.

* Adds simple demo application showing Flask-Menu in action.  E.g. how
  to see it running: `fig up && firefox http://0.0.0.0:5000/first`.

* NOTE Also sets the upper limit on the version of `coverage` since the
  latest one was found to be failing.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>