### PR TITLE
docker: addition of `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+*.egg-info/
+*.egg/
+*.o
+*.pyc
+*.so
+.cache
+.coverage
+.git
+.tox
+__pycache__/
+build/
+dist/


### PR DESCRIPTION
* Adds `.dockerignore` excluding among others Python cache files.  This
  solves a problem when using both `tox` and `docker` to run the test
  suite on the same host, as in:

     $ tox -e py27
     $ docker run flaskmenu_web python setup.py test

* Note that when running tests via `docker-compose`, one still needs to
  clean `__pycache__` manually before running the test suite, due to
  local directory mounting:

     $ find . -name __pycache__ -exec rm -rf {} \;
     $ docker-compose run web python setup.py test

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>