### PR TITLE
menu: improvement of default `item.active`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@ Contact us at `info@invenio-software.org <mailto:info@invenio-software.org>`_
 * Matthew Dillon <mrdillon@alaska.edu>
 * Eirini Psallida <eirini.psallida@cern.ch>
 * Florian Merges <fmerges@fstarter.org>
+* Marco Neumann <marco@crepererum.net>

--- a/flask_menu/__init__.py
+++ b/flask_menu/__init__.py
@@ -82,7 +82,11 @@ class MenuEntryMixin(object):
 
     def _active_when(self):
         """Define condition when a menu entry is active."""
-        return request.endpoint == self._endpoint
+        matching_endpoint = request.endpoint == self._endpoint
+        matching_subpath = len(self.url) > 1 \
+            and request.path.startswith(self.url)
+        matching_completpath = request.path == self.url
+        return matching_endpoint or matching_subpath or matching_completpath
 
     def register(self, endpoint, text, order=0,
                  endpoint_arguments_constructor=None,


### PR DESCRIPTION
* BETTER Improves how the default active state of items is determined.
  Extends test suite for this property.

Signed-off-by: Marco Neumann <marco@crepererum.net>
Reviewed-by: Jiri Kuncar <jiri.kuncar@cern.ch>