### PR TITLE
global: Python 3 compatibility fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ env:
 
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
 
 before_install:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,18 +105,11 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme_path = ['_themes']
-html_theme = 'flask_small'
-
+html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-    'index_logo': False,
-    'index_logo_height': '40px;',
-    'github_fork': 'inveniosoftware/flask-menu',
-}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []

--- a/flask_menu/__init__.py
+++ b/flask_menu/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-Menu
-# Copyright (C) 2013, 2014, 2015 CERN.
+# Copyright (C) 2013, 2014, 2015, 2017 CERN.
 #
 # Flask-Menu is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -16,6 +16,7 @@ import inspect
 import types
 
 from flask import Blueprint, current_app, request, url_for, g
+from six import PY3
 
 from werkzeug.local import LocalProxy
 
@@ -117,7 +118,9 @@ class MenuEntryMixin(object):
         self._endpoint_arguments_constructor = endpoint_arguments_constructor
         self._dynamic_list_constructor = dynamic_list_constructor
         if active_when is not None:
-            if len(inspect.getargspec(active_when)[0]) == 1:
+            active_when_param = inspect.getfullargspec(active_when)[0] \
+                if PY3 else inspect.getargspec(active_when)[0]
+            if len(active_when_param) == 1:
                 self._active_when = types.MethodType(active_when, self)
             else:
                 self._active_when = active_when
@@ -347,7 +350,8 @@ def register_menu(app, path, text, order=0,
             endpoint = f.__name__
             before_first_request = app.before_first_request
 
-        expected = inspect.getargspec(f).args
+        expected = inspect.getfullargspec(f).args if PY3 else \
+            inspect.getargspec(f).args
 
         @before_first_request
         def _register_menu_item():

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,6 @@
 source-dir = docs/
 build-dir = docs/_build
 all_files = 1
+
+[pydocstyle]
+add_ignore = D401

--- a/setup.py
+++ b/setup.py
@@ -123,8 +123,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Development Status :: 5 - Production/Stable'
     ],


### PR DESCRIPTION
* Replaces inspect.getargspec with inspect.getfullargspec for Python 3
  to suppress deprecation warnings.

Signed-off-by: Sebastian Witowski <witowski.sebastian@gmail.com>