### PR TITLE
Fix `active_item` to return real active item and not get stuck on self.

### DIFF
--- a/flask_menu/__init__.py
+++ b/flask_menu/__init__.py
@@ -227,13 +227,13 @@ class MenuEntryMixin(object):
         active child if there is one. If there are no active menu items,
         None will be returned.
         """
-        if self.active:
-            return self
-
         for child in self.children:
             active = child.active_item
             if active is not None:
                 return active
+
+        if self.active:
+            return self
 
         return None
 


### PR DESCRIPTION
Because the function 'active_item' first checks self active it never gets to check if children are active.
By design a parent is marked as active if a child is active.